### PR TITLE
Updated Dockerfile's image tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GOPROXY=''
 
-FROM golang:1.17.3-alpine3.14 AS builder
+FROM golang:1.24.4-alpine3.22 AS builder
 ARG GOPROXY
 
 LABEL maintainer="Phil Pennock <noc+openpgpkey@pennock-tech.com>"


### PR DESCRIPTION
When building the Dockerfile, we face errors because the latest branch of Caddy is no longer compatible with the actual version of Golang.

I've then made the following changes:
- Updated the **Golang** image from `1.17` to `1.24`
- Updated the **Alpine** variant from `3.14` to `3.22`